### PR TITLE
fix: fix port and security for sending emails

### DIFF
--- a/routes/send-email.js
+++ b/routes/send-email.js
@@ -14,9 +14,9 @@ const sendEmail = async (req, res) => {
 
   // Create a transporter using Gmail (or another email service)
   const transporter = nodemailer.createTransport({
-    secure: true, // TLC & SSL options
-    host: "smtp.gmail.com",
-    port: 465,
+    host: "smtp.gmail.com", // Gmail SMTP host
+    port: 587, // Port for TLS/STARTTLS
+    secure: false, // Use 'true' for port 465 (SSL), 'false' for port 587 (TLS)
     auth: {
       user: process.env.GMAIL_USER,
       pass: process.env.GMAIL_PASS,

--- a/routes/send-email.js
+++ b/routes/send-email.js
@@ -17,6 +17,10 @@ const sendEmail = async (req, res) => {
     host: "smtp.gmail.com", // Gmail SMTP host
     port: 587, // Port for TLS/STARTTLS
     secure: false, // Use 'true' for port 465 (SSL), 'false' for port 587 (TLS)
+    requireTLS: true,
+    tls: {
+      minVersion: 'TLSv1.2',
+    },
     auth: {
       user: process.env.GMAIL_USER,
       pass: process.env.GMAIL_PASS,

--- a/vercel.json
+++ b/vercel.json
@@ -9,10 +9,11 @@
   
     "public": true,
   
-    "rewrites": [
+    "routes": [
       {
-        "source": "/routes/send-email",
-        "destination": "/index.js"
+        "src": "/routes/send-email",
+        "dest": "/index.js",
+        "methods": ["POST"]
       }
     ]
   }

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
   
     "routes": [
       {
-        "src": "/routes/send-email",
+        "src": "^/routes/send-email$",
         "dest": "/index.js",
         "methods": ["POST"]
       }

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
   
     "rewrites": [
       {
-        "source": "/(.*)",
+        "source": "/routes/send-email",
         "destination": "/index.js"
       }
     ]

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
     "installCommand": "npm install",
     "outputDirectory": "public",
   
-    "cleanUrls": true,
+    
   
     "public": true,
   


### PR DESCRIPTION
**Title: Fix email sending error**

**Description:**
- Set default port to 587 and set the security to false for non-SSL sending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of outgoing emails by switching to a more robust secure transport, reducing intermittent send and connection failures.

* **Chores**
  * Deployment routing tightened so only POST requests to the email-send endpoint are routed.
  * Added clarifying inline comments to aid future maintenance.
  * No changes to user-facing email flows or API signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->