### PR TITLE
fix: remove untrusted cloudflare server scripts

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -16,7 +16,7 @@
         <p>We're sorry, but the page you are looking for doesn't exist.</p>
         <a href="/" class="btn">Go to Home</a>
     </div>    
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.0/js/bootstrap.min.js"></script>
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script> -->
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.0/js/bootstrap.min.js"></script> -->
 </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -15,8 +15,6 @@
         <h2>Oops! Page Not Found</h2>
         <p>We're sorry, but the page you are looking for doesn't exist.</p>
         <a href="/" class="btn">Go to Home</a>
-    </div>    
-<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script> -->
-<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.0/js/bootstrap.min.js"></script> -->
+    </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -16,7 +16,5 @@
         <p>Sorry, something went wrong on our end. Please try again later.</p>
         <a href="/" class="btn">Go to Home</a>
     </div>
-<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script> -->
-<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.0/js/bootstrap.min.js"></script> -->
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -16,7 +16,7 @@
         <p>Sorry, something went wrong on our end. Please try again later.</p>
         <a href="/" class="btn">Go to Home</a>
     </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.0/js/bootstrap.min.js"></script>
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/2.9.2/umd/popper.min.js"></script> -->
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.1.0/js/bootstrap.min.js"></script> -->
 </body>
 </html>


### PR DESCRIPTION
_Description:_ 
Remove unsecured cloudflare scripts 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed external JavaScript (Popper.js and Bootstrap JS) from the 404 and 500 error pages, reducing external load and simplifying error-page asset requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->